### PR TITLE
Added Klokurier Links

### DIFF
--- a/redirects.toml
+++ b/redirects.toml
@@ -265,7 +265,7 @@ title = "Klokurier"
 [[section.link]]
 desc = "Anmeldung Kneipentour"
 source = "/kneip"
-target = "forms.gle/x9nUhedaU9c4W73z5 "
+target = "https://forms.gle/x9nUhedaU9c4W73z5"
 
 [[section.link]]
 desc = "Erstiheft Informatik"


### PR DESCRIPTION
In order to promote unia.xyz and in order to keep authority over distributed links, Klokurier decided to use unia.xyz