### PR TITLE
Updated redirects.toml with link to feedback-pad

### DIFF
--- a/redirects.toml
+++ b/redirects.toml
@@ -307,3 +307,9 @@ source = "/kneip"
 target = "https://docs.google.com/forms/d/e/1FAIpQLSdl49Jky-DgLUZ8LihTScW8UPUYQ1O3kyMw7vVq4m-CvSFnfg/viewform"
 
 
+[[section]]
+title = "Feedback"
+[[section.link]]
+desc = "Feedback-Pad der Fachschaft Informatik und Fachschaft Mathe"
+source = "/feedback"
+target = "https://pentapad.c3d2.de/p/Feedback"


### PR DESCRIPTION
The added link is a pentapad where people can leave feedback regarding Fachschafts-events. @Fanest knows.